### PR TITLE
Move $class property assignment to allow for access to this.$class in __init__

### DIFF
--- a/classy.js
+++ b/classy.js
@@ -123,9 +123,9 @@
       if (disable_constructor)
         return;
       var proper_this = context === this ? cheapNew(arguments.callee) : this;
+      proper_this.$class = rv;
       if (proper_this.__init__)
         proper_this.__init__.apply(proper_this, arguments);
-      proper_this.$class = rv;
       return proper_this;
     }
 


### PR DESCRIPTION
Is there a reason why [$class is assigned after **init** is called](https://github.com/mitsuhiko/classy/blob/8cbdf07c11327ea3a45838613f5446540a4e0f99/classy.js#L128)?  I went ahead and changed it for my purposes.
