### PR TITLE
Absence of "new" works in more cases.

### DIFF
--- a/classy.js
+++ b/classy.js
@@ -5,11 +5,12 @@
  * :license: BSD.
  */
 !function (context) {
+'use strict';
 !function (definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else context.Class = definition()
-}(function (undefined) { 'use strict';
+}(function (undefined) { 
   var
     CLASSY_VERSION = '1.4',
     old = context.Class,

--- a/classy.js
+++ b/classy.js
@@ -122,7 +122,7 @@
     var rv = function() {
       if (disable_constructor)
         return;
-      var proper_this = context === this ? cheapNew(arguments.callee) : this;
+      var proper_this = this instanceof arguments.callee ? this : cheapNew(arguments.callee);
       if (proper_this.__init__)
         proper_this.__init__.apply(proper_this, arguments);
       proper_this.$class = rv;

--- a/classy.js
+++ b/classy.js
@@ -8,7 +8,7 @@
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
   else this.Class = definition()
-}(function (undefined) {
+}(function (undefined) { 'use strict';
   var
     CLASSY_VERSION = '1.4',
     context = this,
@@ -122,7 +122,7 @@
     var rv = function() {
       if (disable_constructor)
         return;
-      var proper_this = this instanceof arguments.callee ? this : cheapNew(arguments.callee);
+      var proper_this = this instanceof rv ? this : cheapNew(rv);
       if (proper_this.__init__)
         proper_this.__init__.apply(proper_this, arguments);
       proper_this.$class = rv;

--- a/classy.js
+++ b/classy.js
@@ -4,14 +4,14 @@
  * :copyright: (c) 2011 by Armin Ronacher. 
  * :license: BSD.
  */
+!function (context) {
 !function (definition) {
   if (typeof module != 'undefined' && module.exports) module.exports = definition()
   else if (typeof define == 'function' && typeof define.amd == 'object') define(definition)
-  else this.Class = definition()
+  else context.Class = definition()
 }(function (undefined) { 'use strict';
   var
     CLASSY_VERSION = '1.4',
-    context = this,
     old = context.Class,
     disable_constructor = false;
 
@@ -159,3 +159,4 @@
   /* export the class */
   return Class;
 });
+}(this);


### PR DESCRIPTION
Since a class can be inside an object, when you instantiate that class without "new", the "this" context in the constructor points to that object, instead of the global context.
