### PR TITLE
Set construction pointer for access to a derived function object.

### DIFF
--- a/classy.js
+++ b/classy.js
@@ -139,7 +139,7 @@
     /* copy prototype and constructor over, reattach $extend and
        return the class */
     rv.prototype = prototype;
-    rv.constructor = rv;
+    rv.prototype.constructor = rv;
     rv.$extend = Class.$extend;
     rv.$withData = Class.$withData;
     return rv;

--- a/tests/core.js
+++ b/tests/core.js
@@ -220,3 +220,15 @@ test('class variable inheritance', function() {
   equal(SubSubTest.bar, SubTest.bar, 'SubSubTest.bar is Test.bar');
   equal(SubSubTest.foo, 999, 'SubSubTest.foo has been overridden');
 });
+
+test('constructor pointer is corrected to class function object', function() {
+  var
+    Sheep = Animal.$extend({}),
+    dolly = Sheep({
+      name: 'Dolly'
+    }),
+    clone = dolly.clone({
+      name: 'Dolly'
+    });
+  ok(clone instanceof Sheep);
+});

--- a/tests/data.js
+++ b/tests/data.js
@@ -19,6 +19,10 @@ var Animal = Class.$extend({
 
   dead: function() {
     return (this.health <= 0);
+  },
+
+  clone: function(options) {
+    return this.constructor(options);
   }
 });
 

--- a/tests/run_tests.html
+++ b/tests/run_tests.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>Classy Test Suite</title>
-    <link rel="stylesheet" href="http://github.com/jquery/qunit/raw/master/qunit/qunit.css" type="text/css" media="screen">
-    <script type="text/javascript" src="http://github.com/jquery/qunit/raw/master/qunit/qunit.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.23.1/qunit.css" type="text/css" media="screen">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/qunit/1.23.1/qunit.js"></script>
     <script type="text/javascript" src="../classy.js"></script>
     <script type="text/javascript" src="data.js"></script>
     <script type="text/javascript" src="core.js"></script>


### PR DESCRIPTION
Now we can write methods on base classes that can instantiate the derived class of which they're an instance.
